### PR TITLE
Python is and not or in support

### DIFF
--- a/themes/One%20Dark.tmTheme
+++ b/themes/One%20Dark.tmTheme
@@ -898,6 +898,17 @@
 				<string>#56B6C2</string>
 			</dict>
 		</dict>
+	<dict>
+			<key>name</key>
+			<string>python keyword operator logical (is, and, not, or, in)</string>
+			<key>scope</key>
+			<string>support.token.decorator.python,keyword.operator.logical</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#c678dd</string>
+			</dict>
+		</dict>
         <dict>
 			<key>name</key>
 			<string>parameter function</string>


### PR DESCRIPTION
Uses keyword.operator.logical to color is and not or in python keywords
Fixes #16 
![screenshot from 2016-09-30 09 53 59](https://cloud.githubusercontent.com/assets/6538645/18994135/5b4a734c-86f4-11e6-91a5-c2154f138ea9.png)
