### PR TITLE
Rust coloring fixes for lifetimes, attributes, standard enum constants, and core traits

### DIFF
--- a/themes/One%20Dark.tmTheme
+++ b/themes/One%20Dark.tmTheme
@@ -1221,7 +1221,7 @@
 			<key>name</key>
 			<string>Rust Lifetime</string>
 			<key>scope</key>
-			<string>rust.token.lifetime</string>
+			<string>rust.token.lifetime,storage.modifier.lifetime.rust</string>
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
@@ -1232,11 +1232,33 @@
 			<key>name</key>
 			<string>Rust Type Core Support</string>
 			<key>scope</key>
-			<string>rust.token.type.params.core.support</string>
+			<string>rust.token.type.params.core.support,support.type.core.rust</string>
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
 				<string>#56B6C2</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Rust Constant Core Support</string>
+			<key>scope</key>
+			<string>support.constant.core.rust</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#d19a66</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Rust Meta Attribute</string>
+			<key>scope</key>
+			<string>meta.attribute.rust</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#bcc199</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
Lifetimes, attributes, standard enum constants, and core traits now match Atom's One Dark.

VSCode (Before)
![vscode-before](https://cloud.githubusercontent.com/assets/221559/22577387/5f2d9c3e-e98f-11e6-8011-e537d56c2728.png)

VSCode (With Changes)
![vscode-after](https://cloud.githubusercontent.com/assets/221559/22577384/5b5e5cce-e98f-11e6-91e0-a3138416fb73.png)

Atom - One Dark
![atom](https://cloud.githubusercontent.com/assets/221559/22577383/58bf97ee-e98f-11e6-8172-09d2117e2d23.png)
