### PR TITLE
Add rule for Python Language Constants and Format Strings

### DIFF
--- a/samples/sample.py
+++ b/samples/sample.py
@@ -35,3 +35,5 @@ def my_func(args):
 
 const = 42
 PI = 3.14
+langConst = True
+NOTHING = None

--- a/samples/sample.py
+++ b/samples/sample.py
@@ -37,3 +37,4 @@ const = 42
 PI = 3.14
 langConst = True
 NOTHING = None
+print '{} {!r}'.format('some string formatted', 'another\nstring')

--- a/themes/OneDark.tmTheme
+++ b/themes/OneDark.tmTheme
@@ -1435,9 +1435,9 @@
       </dict>
       <dict>
         <key>name</key>
-        <string>[VSCODE-CUSTOM] Python Language Constants</string>
+        <string>[VSCODE-CUSTOM] Python Language Constants and Format String Specifier</string>
         <key>scope</key>
-        <string>source.python constant.language.python</string>
+        <string>source.python constant.language.python,constant.character.format.placeholder.other.python</string>
         <key>settings</key>
         <dict>
           <key>foreground</key>

--- a/themes/OneDark.tmTheme
+++ b/themes/OneDark.tmTheme
@@ -1435,6 +1435,17 @@
       </dict>
       <dict>
         <key>name</key>
+        <string>[VSCODE-CUSTOM] Python Language Constants</string>
+        <key>scope</key>
+        <string>source.python constant.language.python</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#D19A66</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
         <string>[VSCODE-CUSTOM] Css Support Constant Value</string>
         <key>scope</key>
         <string>support.constant.property-value.css</string>


### PR DESCRIPTION
This is for python language constants such as `True`, `False`, and `None`